### PR TITLE
Track sourceless and ignore replica update time

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -41,7 +41,7 @@ def cache_tree(config_age, location_suffix):
 
             if not os.path.exists(cache_location) or \
                     (time.time() - os.stat(cache_location).st_mtime) > \
-                    config.config_dict().get(config_age, 0) * 24 * 3600:
+                    float(config.config_dict().get(config_age, 0)) * 24 * 3600:
 
                 LOG.info('Cache is no good, getting new tree')
                 tree = func(site)

--- a/checkphedex.py
+++ b/checkphedex.py
@@ -29,7 +29,7 @@ def set_of_deletions(site):
     """
 
     created_since = int(
-        time.time() - config.config_dict().get('IgnoreAge', 0) * 24 * 3600)
+        time.time() - float(config.config_dict().get('IgnoreAge', 0)) * 24 * 3600)
 
 
     # Get deletion requests in PhEDEx

--- a/datatypes.py
+++ b/datatypes.py
@@ -26,7 +26,7 @@ from Queue import Empty
 from . import config
 
 LOG = logging.getLogger(__name__)
-IGNORE_AGE = config.config_dict()['IgnoreAge']
+IGNORE_AGE = float(config.config_dict()['IgnoreAge'])
 """
 The maximum age, in days, of files and directories to ignore in this check.
 This variable should be reset once in a while by deamons that run while an

--- a/getinventorycontents.py
+++ b/getinventorycontents.py
@@ -117,7 +117,7 @@ def get_db_listing(site):
 
     curs.execute(
         """
-        SELECT files.name, files.size, dataset_replicas.last_block_created
+        SELECT files.name, files.size
         FROM block_replicas
         INNER JOIN sites ON block_replicas.site_id = sites.id
         INNER JOIN files ON block_replicas.block_id = files.block_id
@@ -135,7 +135,7 @@ def get_db_listing(site):
 
     files_to_add = []
     look_dir = ''
-    name, size, date_time = curs.fetchone() or ('', 0, None)
+    name, size = curs.fetchone() or ('', 0)
 
     while name:
         current_directory = name.split('/')[2]
@@ -147,9 +147,9 @@ def get_db_listing(site):
 
         if current_directory == look_dir:
             LOG.debug('Adding file: %s, %i', name, size)
-            files_to_add.append((name, size, time.mktime(date_time.timetuple())))
+            files_to_add.append((name, size))
 
-        name, size, date_time = curs.fetchone() or ('', 0, None)
+        name, size = curs.fetchone() or ('', 0)
 
     tree = datatypes.DirectoryInfo('/store')
     tree.add_file_list(files_to_add)

--- a/prod/compare.py
+++ b/prod/compare.py
@@ -152,7 +152,7 @@ def main(site):
     conn = sqlite3.connect(os.path.join(webdir, 'stats.db'))
     curs = conn.cursor()
 
-    curs.execute('REPLACE INTO stats_v3 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, DATETIME())',
+    curs.execute('REPLACE INTO stats_v3 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, DATETIME(DATETIME(), "-4 hours"))',
                  (site, time.time() - start, site_tree.get_num_files(),
                   site_tree.count_nodes(), len(site_tree.empty_nodes_list()),
                   config.config_dict().get('NumThreads', config.config_dict().get('MinThreads', 0)),

--- a/prod/consistency_config.json
+++ b/prod/consistency_config.json
@@ -6,7 +6,7 @@
   "ListAge": 5,
   "IgnoreAge": 7,
   "RedirectorAge": 50,
-  "CacheLocation": "/home/dabercro/OpsSpace/ConsistencyCheck/prod/cache",
+  "CacheLocation": "/scratch5/dabercro/consistency_cache",
   "Redirectors": {
     "T3_CH_PSI": "t3se01.psi.ch",
     "T3_US_MIT": "t3serv006.mit.edu"


### PR DESCRIPTION
- The webpage now includes the number of missing files that do not have other disk sources that dynamo knows about.
- The dynamo listing no longer uses timestamps to know which blocks replicas to ignore for orphans, just the is_complete flag.