### PR TITLE
Allow DirectoryList to be overwritten

### DIFF
--- a/config.py
+++ b/config.py
@@ -31,6 +31,13 @@ If your ``CONFIG_FILE`` is not a JSON file, you'll want to change this
 also before calling :py:func:`config_dict`.
 """
 
+DIRECTORYLIST = None
+"""
+If this is set to a list of directories, it overrides the
+``DirectoryList`` set in the configuration file.
+This prevents the tool from attempting to list directories that are not there.
+"""
+
 def config_dict(make_dir=True):
     """
     :param bool make_dir: Create the cache directory if it's missing
@@ -81,6 +88,8 @@ def config_dict(make_dir=True):
         else:
             raise KeyError('Configuration dictionary does not have a %s set. '
                            'Using dictionary at %s' % (key, location))
+
+    output['DirectoryList'] = DIRECTORYLIST or output['DirectoryList']
 
     return output
 

--- a/getsitecontents.py
+++ b/getsitecontents.py
@@ -111,7 +111,7 @@ class XRootDLister(object):
             # Retry certain error codes if there's no dir_list
             # Don't bother with 3010 at the moment because there's that Hadoop bug
             okay = (error_code == '3010' and 'operation not permitted' in status.message) or \
-                (bool(dir_list) if error_code in ['!', '3005'] else False)
+                (bool(dir_list) and error_code in ['!', '3005'])
 
             self.log.debug('Error code: %s', error_code)
             self.log.debug('Directory List: %s', dir_list)

--- a/getsitecontents.py
+++ b/getsitecontents.py
@@ -110,7 +110,7 @@ class XRootDLister(object):
 
             # Retry certain error codes if there's no dir_list
             # Don't bother with 3010 at the moment because there's that Hadoop bug
-            okay = error_code == '3010' or \
+            okay = (error_code == '3010' and 'operation not permitted' in status.message) or \
                 (bool(dir_list) if error_code in ['!', '3005'] else False)
 
             self.log.debug('Error code: %s', error_code)

--- a/prod/compare.py
+++ b/prod/compare.py
@@ -167,6 +167,10 @@ def main(site):
     status_check.close()
 
     inv_tree = getinventorycontents.get_db_listing(site)
+
+    # Reset the DirectoryList for the XRootDLister to run on
+    config.DIRECTORYLIST = [directory.name for directory in inv_tree.directories]
+
     site_tree = getsitecontents.get_site_tree(site)
 
     # Get whether or not the site is debugged

--- a/web/explanations.html
+++ b/web/explanations.html
@@ -55,6 +55,7 @@
     <h3>Unlisted</h3>
 
     This is the number of nodes that claim to be not successfully listed.
+    If this number is not zero, the column is highlighted as a red cell.
 
     <h3>Empty Nodes</h3>
 

--- a/web/output.html
+++ b/web/output.html
@@ -67,6 +67,7 @@
            $background_nosource = ($row['nosource'] > $row['files']/10) ? $bad_background : '';
            $background_orphan = ($row['orphan'] > $row['files']/10) ? $bad_background : '';
            $background_files = ($row['files'] == 0) ? $bad_background : '';
+           $background_unlisted = ($row['unlisted'] != 0) ? $bad_background : '';
 
            if ($row['isrunning'] == 0) {
              $background_site = $background_files;
@@ -77,10 +78,11 @@
            $background_time = ((strtotime($row['entered']) + 24 * 3600) > time()) ? $good_background : '';
 
            printf (
-             '<tr><td%s>%s</td><td%s><a href="%s.log">%s</a></td><td>%.0f</td><td%s>%d</td><td>%d</td><td>%d</td><td>%d</td><td%s><a href="%s_compare_missing.txt">%d</a> [<a href="%s_missing_datasets.txt">blocks</a>]</td><td%s><a href="%s_missing_nosite.txt">%d</a></td><td>%.2f</td><td%s><a href="%s_compare_orphan.txt">%d</a></td><td>%.2f</td></tr>',
+             '<tr><td%s>%s</td><td%s><a href="%s.log">%s</a></td><td>%.0f</td><td%s>%d</td><td>%d</td><td%s>%d</td><td>%d</td><td%s><a href="%s_compare_missing.txt">%d</a> [<a href="%s_missing_datasets.txt">blocks</a>]</td><td%s><a href="%s_missing_nosite.txt">%d</a></td><td>%.2f</td><td%s><a href="%s_compare_orphan.txt">%d</a></td><td>%.2f</td></tr>',
              $background_time, $row['entered'],
              $background_site, $row['site'], $row['site'], $row['time']/60.,
-             $background_files, $row['files'], $row['nodes'], $row['unlisted'], $row['emtpy'],
+             $background_files, $row['files'], $row['nodes'], 
+             $background_unlisted, $row['unlisted'], $row['emtpy'],
              $background_missing, $row['site'], $row['missing'], $row['site'],
              $background_nosource, $row['site'], $row['nosource'], $row['m_size']/pow(1024.,4),
              $background_orphan, $row['site'], $row['orphan'], $row['o_size']/pow(1024.,4));


### PR DESCRIPTION
Part of the unlisted directories come from attempting to list directories that dynamo doesn't even expect.
- Stop trying those listings
- Improve visibility of unlisted errors
- Try to separate Hadoop bug from permission problems (throws same error code)