### PR TITLE
"/cms" fallback

### DIFF
--- a/prod/consistency_config.json
+++ b/prod/consistency_config.json
@@ -9,6 +9,7 @@
   "CacheLocation": "/local/dynamo/consistency/cache",
   "LogLocation": "/local/dynamo/consistency/logs",
   "Redirectors": {
+    "T2_UK_London_Brunel": "dc2-grid-64.brunel.ac.uk",
     "T3_CH_PSI": "t3se01.psi.ch",
     "T3_US_MIT": "t3serv006.mit.edu"
   },

--- a/prod/consistency_config.json
+++ b/prod/consistency_config.json
@@ -12,6 +12,9 @@
     "T3_CH_PSI": "t3se01.psi.ch",
     "T3_US_MIT": "t3serv006.mit.edu"
   },
+  "PathPrefix": {
+    "T2_UK_London_Brunel": "/cms"
+  },
   "DirectoryList": [
     "mc",
     "data",

--- a/prod/kill_and_disable.sh
+++ b/prod/kill_and_disable.sh
@@ -39,7 +39,6 @@ then
             pkill -P $compare_pid
             # Kill the process
             kill $compare_pid
-            break
 
         fi
 

--- a/prod/run_checks.sh
+++ b/prod/run_checks.sh
@@ -60,8 +60,9 @@ then
 
     fi
 
-    # Source dynamo
-    . $HOME/dynamo/etc/profile.d/init.sh
+    # Setup environment
+    # (sources dynamo and sets PYTHONPATH
+    . $HERE/set_env.sh
 
     # Lock all sites first
     echo "UPDATE sites SET isrunning = 1 WHERE site = '$(echo $SITES | sed "s/ /' OR site = '/g")';" | sqlite3 $DATABASE
@@ -84,7 +85,7 @@ then
         LOGFILE=${SITE}_$(date +%y%m%d_%H%M%S).log
 
         # Run
-        PYTHONPATH=$(dirname $(dirname $HERE)):$HOME/dynamo/lib $HERE/compare.py $SITE watch &> $LOGLOCATION/$LOGFILE
+        $HERE/compare.py $SITE watch &> $LOGLOCATION/$LOGFILE
 
         # Copy log file to web location
         cp $LOGLOCATION/$LOGFILE $(jq -r '.WebDir' $HERE/consistency_config.json)/${SITE}.log

--- a/prod/set_env.sh
+++ b/prod/set_env.sh
@@ -1,0 +1,7 @@
+#! /bin/bash
+
+# Source dynamo
+. $HOME/dynamo/etc/profile.d/init.sh
+
+# Set PYTHONPATH
+export PYTHONPATH=$(dirname $(dirname $HERE)):$HOME/dynamo/lib:$PYTHONPATH

--- a/test/config.yml
+++ b/test/config.yml
@@ -1,6 +1,9 @@
 ##!
 #
-# - **DirectoryList** - A list of directories inside of ``'/store/'`` to check consistency.
+# - **DirectoryList** - A list of directories inside of ``/store/`` to check consistency.
+# - **PathPrefix** - A dictionary of prefixes to place before ``/store/`` in the XRootD call.
+#   If the prefix is not set for a site, and it fails to list ``/store``, it tries ``/cms/store``
+#   (prefix ``'/cms'``) by default.
 # - **MaxMissing** - If more files than this number are missing,
 #   then there will be no automatic entry into the register
 # - **MaxOrphan** - If more than files than this number are orphan files at a site,
@@ -63,6 +66,9 @@ RedirectorAge: 1
 Redirectors:
   T3_US_MIT: t3serv006.mit.edu
   T3_CH_PSI: t3se01.psi.ch
+
+PathPrefix:
+  T2_UK_London_Brunel: /cms
 
 DirectoryList:
   - mc

--- a/test/consistency_config.json
+++ b/test/consistency_config.json
@@ -16,7 +16,7 @@
   },
   "PathPrefix": {
     "T2_UK_London_Brunel": "/cms"
-  }
+  },
   "DirectoryList": [
     "mc",
     "data",

--- a/test/consistency_config.json
+++ b/test/consistency_config.json
@@ -14,6 +14,9 @@
     "T3_CH_PSI": "t3se01.psi.ch",
     "T3_US_MIT": "t3serv006.mit.edu"
   },
+  "PathPrefix": {
+    "T2_UK_London_Brunel": "/cms"
+  }
   "DirectoryList": [
     "mc",
     "data",


### PR DESCRIPTION
- Fall back on /cms/store if listing /store does not work at the beginning
- Allow for this prefix to be set individually for each site (to save bad /store calls and add flexibility
- Separated environment setup to make script running easier as user dynamo
- Prevent the kill script from stopping after first matched process in case multiple users are running on a site at the same time