### PR TITLE
Web history

### DIFF
--- a/datatypes.py
+++ b/datatypes.py
@@ -60,9 +60,9 @@ def create_dirinfo(location, first_dir, filler, object_params=None):
     :param list object_params: This only needs to be set when filler is an object constructor.
                                Each element in the list is a tuple of arguments to pass
                                to the constructor.
-    :returns: A DirectoryInfo containing everything the directory listings from
+    :returns: A :py:class:`DirectoryInfo` object containing everything the directory listings from
               ``os.path.join(location, first_dir)`` with name ``first_dir``.
-    :rtype: :py:class:`DirectoryInfo`
+    :rtype: DirectoryInfo
     """
 
     LOG.debug('Called create_dirinfo(%s, %s, %s, %s)',
@@ -311,7 +311,7 @@ class DirectoryInfo(object):
 
         :param str name: The name of the directory
         :param list to_merge: If this is set, the infos in the
-                              list are merged into a master DirectoryInfo.
+                              list are merged into a master :py:class:`DirectoryInfo`.
         :param list directories: List of subdirectories inside the directory
         :param list files: List of tuples containing information about files
                            in the directory.
@@ -334,7 +334,7 @@ class DirectoryInfo(object):
 
     def add_files(self, files):
         """
-        Set the files for this DirectoryInfo node
+        Set the files for this :py:class:`DirectoryInfo` node
 
         :param list files: The tuples of file information.
                            Each element consists of file name, size, and mod time.
@@ -405,7 +405,7 @@ class DirectoryInfo(object):
 
     def setup_hash(self):
         """
-        Set the hashes for this DirectoryInfo
+        Set the hashes for this :py:class:`DirectoryInfo`
         """
 
         hasher = hashlib.sha1()
@@ -446,7 +446,7 @@ class DirectoryInfo(object):
 
     def save(self, file_name):
         """
-        Save this DirectoryInfo in a file.
+        Save this :py:class:`DirectoryInfo` in a file.
 
         :param str file_name: is the location to save the file
         """
@@ -456,17 +456,17 @@ class DirectoryInfo(object):
 
     def display(self, path=''):
         """
-        Print out the contents of this DirectoryInfo
+        Print out the contents of this :py:class:`DirectoryInfo`
 
-        :param str path: The full path to this DirectoryInfo instance
+        :param str path: The full path to this :py:class:`DirectoryInfo` instance
         """
         print self.displays(path)
 
     def displays(self, path=''):
         """
-        Get the string to print out the contents of this DirectoryInfo.
+        Get the string to print out the contents of this :py:class:`DirectoryInfo`.
 
-        :param str path: The full path to this DirectoryInfo instance
+        :param str path: The full path to this :py:class:`DirectoryInfo` instance
         :returns: The display string
         :rtype: str
         """
@@ -558,7 +558,7 @@ class DirectoryInfo(object):
         Grabs the subdirectories by the first in the list.
 
         :param int levels: is the number of levels of directories to bypass
-        :returns: The proper DirectoryInfo level
+        :returns: The proper :py:class:`DirectoryInfo` level
         :rtype: DirectoryInfo
         """
 
@@ -697,7 +697,7 @@ class DirectoryInfo(object):
 
     def listdir(self, *args, **kwargs):
         """
-        Get the list of directory names within a DirectoryInfo.
+        Get the list of directory names within a :py:class:`DirectoryInfo`.
         Adding an argument will display the contents of the next directory.
         For example, if ``dir.listdir()`` returns::
 
@@ -709,7 +709,7 @@ class DirectoryInfo(object):
 
         :param args: Is a list of indices to list the subdirectories
         :param kwargs: Supports 'printing' which is set to a bool. Defaults as True.
-        :returns: The DirectoryInfo that is being listed
+        :returns: The :py:class:`DirectoryInfo` that is being listed
         :rtype: DirectoryInfo
         """
 
@@ -765,7 +765,7 @@ class DirectoryInfo(object):
 
 def get_info(file_name):
     """
-    Get the DirectoryInfo from a file.
+    Get the :py:class:`DirectoryInfo` from a file.
 
     :param str file_name: is the location of the saved information
     :returns: Saved info

--- a/prod/consistency_config.json
+++ b/prod/consistency_config.json
@@ -25,6 +25,7 @@
     "himc"
   ],
   "BothList": [
+    "T2_FR_CCIN2P3",
     "T1_US_FNAL"
   ],
   "GlobalRedirectors": [

--- a/prod/set_env.sh
+++ b/prod/set_env.sh
@@ -3,5 +3,7 @@
 # Source dynamo
 . $HOME/dynamo/etc/profile.d/init.sh
 
+HERE=$(cd $(dirname $BASH_SOURCE) && pwd)
+
 # Set PYTHONPATH
 export PYTHONPATH=$(dirname $(dirname $HERE)):$HOME/dynamo/lib:$PYTHONPATH

--- a/web/output.html
+++ b/web/output.html
@@ -23,7 +23,7 @@
           <th onclick="sorttable(1, false)">
             Last Update
           </th>
-          <th onclick="sorttable(-2, false)">
+          <th<?php if (!isset($_GET['history'])) echo(' onclick="sorttable(-2, false)"');?>>
             Site Name
           </th>
           <th onclick="sorttable(3)">
@@ -74,34 +74,43 @@
            $tooltip = '';
 
            // Get the running cell colored based on running status
-           switch ($row['isrunning']) {
+           if (isset($_GET['history'])) {
+             $background_site = $background_files;
+           } else {
+             switch ($row['isrunning']) {
 
-             case 0:
-               $background_site = $background_files;
-               break;
-             case 1:
-               $background_site = $queued_background;
-               break;
-             case 2:
-               $background_site = ((strtotime($row['laststarted']) + 24 * 3600) > time()) ? $good_background : $long_background;
-               $tooltip = '<span class="givestarted">Started run: ' . $row['laststarted'] . '</span>';
-               break;
-             default:
-               $background_site = $disabled_background;
+               case 0:
+                 $background_site = $background_files;
+                 break;
+               case 1:
+                 $background_site = $queued_background;
+                 break;
+               case 2:
+                 $background_site = ((strtotime($row['laststarted']) + 24 * 3600) > time()) ? $good_background : $long_background;
+                 $tooltip = '<span class="givestarted">Started run: ' . $row['laststarted'] . '</span>';
+                 break;
+               default:
+                 $background_site = $disabled_background;
 
+             }
            }
 
            $background_time = ((strtotime($row['entered']) + 24 * 3600) > time()) ? $good_background : '';
 
-           printf (
-             '<tr><td%s>%s</td><td%s><a href="%s.log">%s</a>%s</td><td>%.0f</td><td%s>%d</td><td>%d</td><td%s>%d</td><td>%d</td><td%s><a href="%s_compare_missing.txt">%d</a> [<a href="%s_missing_datasets.txt">blocks</a>]</td><td%s><a href="%s_missing_nosite.txt">%d</a></td><td>%.2f</td><td%s><a href="%s_compare_orphan.txt">%d</a></td><td>%.2f</td></tr>',
-             $background_time, $row['entered'],
+           $html_row = sprintf(
+             '<td%s><a href="?history=%s">%s</a></td><td%s><a href="%s.log">%s</a>%s</td><td>%.0f</td><td%s>%d</td><td>%d</td><td%s>%d</td><td>%d</td><td%s><a href="%s_compare_missing.txt">%d</a> [<a href="%s_missing_datasets.txt">blocks</a>]</td><td%s><a href="%s_missing_nosite.txt">%d</a></td><td>%.2f</td><td%s><a href="%s_compare_orphan.txt">%d</a></td><td>%.2f</td>',
+             $background_time, $row['site'], $row['entered'],
              $background_site, $row['site'], $row['site'], $tooltip, $row['time']/60.,
              $background_files, $row['files'], $row['nodes'], 
              $background_unlisted, $row['unlisted'], $row['emtpy'],
              $background_missing, $row['site'], $row['missing'], $row['site'],
              $background_nosource, $row['site'], $row['nosource'], $row['m_size']/pow(1024.,4),
              $background_orphan, $row['site'], $row['orphan'], $row['o_size']/pow(1024.,4));
+
+           if (isset($_GET['history'])) {
+             $html_row = strip_tags($html_row, '<td>');
+           }
+           printf('<tr>%s</tr>', $html_row);
            printf("\n");
          }
 ?>

--- a/web/sorttable.js
+++ b/web/sorttable.js
@@ -1,15 +1,17 @@
 
-var howSorted = -2;          // Starts out sorted by Site Name Ascending
+// Starts out sorted by Site Name Ascending or Entered for history
+var howSorted = (window.location.search.indexOf('history') > 0) ? 1 : -2;
 
 function extractkey (text, is_number) {
     // A function for getting the comparison key from the cell contents
 
     var output = text;
 
+    if (output.indexOf('href') > 0) {
+        output = output.split('>')[1].split('<')[0];
+    }
+
     if (is_number) {
-        if (output.indexOf('href') > 0) {
-            output = output.split('>')[1].split('<')[0];
-        }
         output = Number(output.split(' ')[0]);
     }
 

--- a/web/stats.php
+++ b/web/stats.php
@@ -13,8 +13,24 @@ $join = '';
 
 if (isset($_GET['history'])) {
 
-  $site = $_GET['history'];
-  $condition = ' WHERE site = "' . $site . '"';
+  $site = SQLite3::escapeString($_GET['history']);
+
+  // Check that $site is really a site
+  $invalid_site = true;
+  $check_result = $db->query('SELECT site FROM sites');
+  while ($check = $check_result->fetchArray()) {
+    if ($check[0] == $site) {
+      $invalid_site = false;
+      break;
+    }
+  }
+
+  if ($invalid_site) {
+    $db = null;
+    die('Invalid site name');
+  }
+
+  $condition = ' WHERE site = \'' . $site . '\'';
   $table = $table . $condition . ' UNION SELECT * FROM ' . $table . '_history';
 
 } else {


### PR DESCRIPTION
- Minor cleaning to Sphinx links
- Fixed the set_env.sh script so it can be sourced from the shell now
- Added a link from the summary page to look at each site's history
- Use both ports for each T2_FR_CCIN2P3 directory listing

Tests will take a while to get through because Travis-CI is having some problem with their Linux VMs: https://www.traviscistatus.com/incidents/4vdl52d28hz3

Until this is merged, examples of the history will be on the test page: http://t3serv001.mit.edu/~dabercro/ConsistencyCheck/?history=T2_US_MIT